### PR TITLE
waitForYellow and refresh index bindings, to allow robust testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+ElasticSearch bindings
+======================
+
+These are the Haskell bindings to ElasticSearch.

--- a/elasticsearch.cabal
+++ b/elasticsearch.cabal
@@ -44,4 +44,5 @@ test-suite tests
                    hspec,
                    aeson,
                    transformers,
-                   text
+                   text,
+                   async

--- a/src/Search/ElasticSearch.hs
+++ b/src/Search/ElasticSearch.hs
@@ -19,6 +19,8 @@ module Search.ElasticSearch
        , Index
        , indexDocument
        , bulkIndexDocuments
+       , waitForYellow
+       , refresh
 
          -- * Searching
        , SearchResults(getResults, totalHits)
@@ -205,6 +207,14 @@ search es index offset query =
         queryParts = [ ("q", escapeURIString isUnescapedInURI (T.unpack query))
                      , ("from", show offset)
                      ]
+
+refresh es index = do
+  void $ dispatchRequest es GET path Nothing
+    where Just path = parseRelativeReference (index ++ "/_refresh")
+
+waitForYellow :: ElasticSearch -> IO ()
+waitForYellow es = void $ dispatchRequest es GET path Nothing
+    where Just path = parseRelativeReference ("/_cluster/health?wait_for_status=yellow")
 
 --------------------------------------------------------------------------------
 -- Private API


### PR DESCRIPTION
I found when testing larger datasets that one second wasn't enough to allow ElasticSearch to catch up.
It was always a dirty hack anyway, so I diked it and had it wait for Yellow, then refresh the index in the tests. This seems to be enough to make it reliably find all the documents it had inserted.

I've also got a currently failing test here using many threads - any ideas on how to resolve the problem would be appreciated, it doesn't look like I'm getting errors back from the library or ES.
